### PR TITLE
Use N-1 workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Now you can SSH to your cluster and start using presto:
 ```
 presto --schema default
 ```
-This will connect to hive metastore via [hive connector](https://prestodb.io/docs/current/connector/hive.html). On a N worker node cluster, you will have N-2 presto worker nodes and 1 coordinator node. The setup also configures [TPCH connector](https://prestodb.io/docs/current/connector/tpch.html), so you can run TPCH queries directly.
+This will connect to hive metastore via [hive connector](https://prestodb.io/docs/current/connector/hive.html). On a N worker node cluster, you will have N-1 presto worker nodes and 1 coordinator node. The setup also configures [TPCH connector](https://prestodb.io/docs/current/connector/tpch.html), so you can run TPCH queries directly.
 
 If you want to configure additional connectors, you can pass the catalog configurations as a parameter to the custom action script. The syntax is `‘connector1’ : [‘key1=value1’, ‘key2=value2’..], ‘connector2’ : [‘key1=value1’, ‘key2=value2’..]` as described in [presto-yarn](https://prestodb.io/presto-yarn/installation-yarn-configuration-options.html). So, the following string as a parameter will add sqlserver and DocDB connectors with its configurations (notice the "" around the full string):
 

--- a/createconfigs.sh
+++ b/createconfigs.sh
@@ -20,7 +20,7 @@ cat > appConfig-default.json <<EOF
     "site.global.app_pkg_plugin": "\${AGENT_WORK_ROOT}/app/definition/package/plugins/",
     "site.global.singlenode": "false",
     "site.global.coordinator_host": "\${COORDINATOR_HOST}",
-    "site.global.presto_query_max_memory": "$(($(($(($memory/1706))-1)) * $(($nodes-2))))GB",
+    "site.global.presto_query_max_memory": "$(($(($(($memory/1706))-1)) * $(($nodes-1))))GB",
     "site.global.presto_query_max_memory_per_node": "$(($(($memory/1706))-1))GB",
     "site.global.presto_server_port": "9090",
     "site.global.catalog": "{ $EXTRA_CONNECTORS 'hive': ['connector.name=hive-hadoop2','hive.metastore.uri=$metastore', 'hive.config.resources=/etc/hadoop/conf/hdfs-site.xml,/etc/hadoop/conf/core-site.xml'], 'tpch': ['connector.name=tpch']}",
@@ -53,11 +53,11 @@ cat > resources-default.json <<EOF
       "yarn.role.priority": "1",
       "yarn.component.instances": "1",
       "yarn.component.placement.policy": "1",
-      "yarn.memory": "$memory"
+      "yarn.memory": "12288"
     },
     "WORKER": {
       "yarn.role.priority": "2",
-      "yarn.component.instances": "$(($nodes-2))",
+      "yarn.component.instances": "$(($nodes-1))",
       "yarn.component.placement.policy": "1",
       "yarn.memory": "$memory"
     }


### PR DESCRIPTION
* Use N-1 presto workers on a N node cluster.
* Use fix 12 GB memory for the coordinator.