### PR TITLE
Improving instructions for HDI 3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,19 +53,30 @@ You can check the script action logs in your default storage account under <STOR
 Yes.
 
 ### Does it work with [Azure Data Lake Store (ADLS)](https://azure.microsoft.com/en-us/services/data-lake-store/)?
-Yes. Following are the instrcutions :
+Yes. Following are the instructions if the cluster is already running:
 1. Go to Ambari -> HDFS -> Configs -> Advanced -> Custom core-site. 
-2. Click on "Add Property" to add following proerties to core-site. The details of this configuration can be found [here](https://hadoop.apache.org/docs/current/hadoop-azure-datalake/index.html):
+2. Click on "Add Property" to add following properties to core-site. The details of this configuration can be found [here](https://hadoop.apache.org/docs/current/hadoop-azure-datalake/index.html):
 
+   2a. For HDInsight 3.5:
+ 
         fs.adl.impl=org.apache.hadoop.fs.adl.AdlFileSystem
         fs.AbstractFileSystem.adl.impl=org.apache.hadoop.fs.adl.Adl
         dfs.adls.oauth2.access.token.provider.type=ClientCredential
         dfs.adls.oauth2.refresh.url=https://login.microsoftonline.com/YOUR_AZURE_AD_TENANT_ID/oauth2/token
         dfs.adls.oauth2.client.id=YOUR_AZURE_SERVICE_PRINCIPAL_ID
         dfs.adls.oauth2.credential=YOUR_AZURE_SERVICE_PRINCIPAL_PASSWORD
+        
+   2b. For HDInsight 3.6:
+
+        dfs.adls.oauth2.access.token.provider.type=ClientCredential
+        dfs.adls.oauth2.refresh.url=https://login.microsoftonline.com/YOUR_AZURE_AD_TENANT_ID/oauth2/token
+        dfs.adls.oauth2.client.id=YOUR_AZURE_SERVICE_PRINCIPAL_ID
+        dfs.adls.oauth2.credential=YOUR_AZURE_SERVICE_PRINCIPAL_PASSWORD
 
 3. Restart the required services by going to Ambari -> Actions -> "Restart All Required"
-4. Now run the presto script action from the azure portal.
+4. Now run the presto script action from the Azure portal.
+
+Alternately, if you are creating a cluster from an ARM template, you can add these properties into the core-site section of the ARM template so that no manual steps will be required after cluster creation.
 
 ### How do I customize presto installation?
 If you want to customize presto (change the memory settings, change connectors etc.), 

--- a/README.md
+++ b/README.md
@@ -66,8 +66,10 @@ Yes. Following are the instructions if the cluster is already running:
         dfs.adls.oauth2.client.id=YOUR_AZURE_SERVICE_PRINCIPAL_ID
         dfs.adls.oauth2.credential=YOUR_AZURE_SERVICE_PRINCIPAL_PASSWORD
         
-   2b. For HDInsight 3.6:
+   2b. For HDInsight 3.6 add any which don't already exist:
 
+        fs.adl.impl=org.apache.hadoop.fs.adl.HdiAdlFileSystem
+        fs.AbstractFileSystem.adl.impl=org.apache.hadoop.fs.adl.HdiAdl
         dfs.adls.oauth2.access.token.provider.type=ClientCredential
         dfs.adls.oauth2.refresh.url=https://login.microsoftonline.com/YOUR_AZURE_AD_TENANT_ID/oauth2/token
         dfs.adls.oauth2.client.id=YOUR_AZURE_SERVICE_PRINCIPAL_ID


### PR DESCRIPTION
Please consider keeping this documentation updated to work with HDI 3.6. I haven't tried on 3.5, but the first two properties are already set and have slightly different values on a HDI 3.6 cluster on ADLS. If I skip the first two properties (fs.adl.impl and fs.AbstractFileSystem.adl.impl) on 3.6 it works.

Also mentioning it works in an ARM template is important as many people spin up and spin down clusters and aren't able to manually touch the config every time.

We also need to get this documentation into the https://docs.microsoft.com/en-us/azure/hdinsight/hdinsight-hadoop-install-presto as it currently says "It must use Azure Storage as the data store. Using Presto on a cluster that uses Azure Data Lake Store as the storage option is not yet supported." Are you able to do that or do I need to create a pull request on the Azure docs too?